### PR TITLE
Don't hard code platform and language in addons.mozilla.org links

### DIFF
--- a/content/_data/links.json
+++ b/content/_data/links.json
@@ -1,6 +1,6 @@
 {
   "source": "https://github.com/hackademix/noscript/",
-  "moz": "https://addons.mozilla.org/en-US/firefox/addon/noscript/",
+  "moz": "https://addons.mozilla.org/addon/noscript/",
   "chrome":"https://chrome.google.com/webstore/detail/noscript/doojmbjmlfjjnbmnoijecmcbfeoakpjm/",
   "nscl_source": "https://github.com/hackademix/nscl/",
   "nlnet": "https://nlnet.nl",


### PR DESCRIPTION
This way, AMO figures out the platform ("firefox" or "android") and the language.

Also, it seems that Noscript currently isn't available from chromewebstore.google.com? Should this perhaps be noted?